### PR TITLE
v0.2.0: CloudEvents support and AWS SNS input

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+FROM rust:1.85-slim
+
+RUN apt-get update && apt-get install -y \
+    pkg-config libssl-dev git curl python3 \
+    awscli jq \
+    && rm -rf /var/lib/apt/lists/*
+
+# Rust tools
+RUN rustup component add clippy rustfmt
+
+WORKDIR /workspace

--- a/.devcontainer/Dockerfile.mock
+++ b/.devcontainer/Dockerfile.mock
@@ -1,0 +1,3 @@
+FROM python:3.12-slim
+COPY tests/mock_server.py /app/mock_server.py
+CMD ["python3", "/app/mock_server.py", "19999"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "name": "qhook",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "dev",
+  "workspaceFolder": "/workspace",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml",
+        "vadimcn.vscode-lldb"
+      ],
+      "settings": {
+        "rust-analyzer.check.command": "clippy"
+      }
+    }
+  },
+  "postCreateCommand": "cargo build",
+  "forwardPorts": [8888, 4566]
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+  dev:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ..:/workspace:cached
+    command: sleep infinity
+    environment:
+      RUST_LOG: qhook=debug
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_DEFAULT_REGION: us-east-1
+      LOCALSTACK_ENDPOINT: http://localstack:4566
+    depends_on:
+      localstack:
+        condition: service_healthy
+
+  localstack:
+    image: localstack/localstack:3
+    ports:
+      - "4566:4566"
+    environment:
+      SERVICES: sns
+      DEFAULT_REGION: us-east-1
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  mock:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile.mock
+    ports:
+      - "19999:19999"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# qhook Development Guide
+
+## Project Overview
+
+qhook is a lightweight webhook receiver with built-in queue and retry. Rust (axum + sqlx + reqwest).
+
+## Development Workflow
+
+### 1. Task Management
+
+- **Tasks live in `KANBAN.md`** at the project root.
+- Before starting work, read KANBAN.md to pick the next task from "In Progress" or "Todo".
+- Move the task to "In Progress" when starting.
+- Move to "Done" when complete, then pick the next task.
+- Add new tasks as they emerge during development.
+
+### 2. Test-Driven Development
+
+Write or update tests **before** implementing features:
+
+1. Write unit tests in `#[cfg(test)] mod tests` within the relevant source file.
+2. Write E2E tests in `tests/e2e.sh` (basic) or `tests/e2e_sns.sh` (SNS/LocalStack).
+3. Run tests to confirm they fail.
+4. Implement the feature.
+5. Run tests to confirm they pass.
+
+### 3. Test Commands
+
+```bash
+# Unit tests (fast, always run)
+cargo test
+
+# E2E tests (starts qhook + mock server, no external deps)
+bash tests/e2e.sh
+
+# SNS E2E tests (requires LocalStack)
+docker run -d --name localstack-qhook -p 4567:4566 -e SERVICES=sns -e LOCALSTACK_HOST=localhost:4567 localstack/localstack:3
+LOCALSTACK_ENDPOINT=http://localhost:4567 bash tests/e2e_sns.sh
+docker rm -f localstack-qhook
+```
+
+### 4. Build
+
+```bash
+cargo build            # debug
+cargo build --release  # release
+```
+
+## Project Structure
+
+```
+src/
+  main.rs       — Entry point (minimal)
+  lib.rs        — Module exports (for Cloud version dependency)
+  api.rs        — HTTP handlers (webhook, event, sns, health)
+  config.rs     — YAML config parsing + env var expansion
+  db.rs         — SQLite/Postgres via sqlx AnyPool
+  queue.rs      — Job worker (poll, deliver, retry, DLQ)
+  verify.rs     — Signature verification (GitHub, Stripe, Shopify, HMAC, SNS X.509)
+  cli.rs        — CLI commands (start, init, validate, jobs, events)
+tests/
+  e2e.sh        — E2E tests (14 tests)
+  e2e_sns.sh    — SNS E2E tests with LocalStack (8 tests)
+  mock_server.py — Python mock HTTP server for E2E
+docs/           — Deployment guides, why-qhook comparison
+examples/       — Example configs, stripe-checkout sample app
+```
+
+## Conventions
+
+- **Language**: Code and comments in English. User communication in Japanese.
+- **Source type strings**: `webhook`, `event`, `sns` (in config YAML and source_type field).
+- **Event type extraction order**: CloudEvents `ce-type` header → structured mode `type` field → provider-specific logic.
+- **Database**: SQLite for dev/testing, Postgres for production. Both via sqlx AnyPool.
+- **IDs**: ULID for event_id and job_id.
+- **Timestamps**: UTC, format `%Y-%m-%dT%H:%M:%S%.3f` stored as TEXT.
+- **Config env vars**: `${VAR}` or `${VAR:-default}` syntax.
+- **Version**: Currently v0.2.0. Update in Cargo.toml for releases.
+- **Docker image**: `ghcr.io/totte-dev/qhook`. Multi-stage build, ~119MB.
+- **Commit**: Include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`.
+
+## Key Design Decisions
+
+- **Single binary, no external deps** — no Redis, no RabbitMQ. The queue is built into qhook.
+- **lib.rs exports all modules** — enables future Cloud version to depend on qhook as a library crate.
+- **skip_verify on SourceConfig** — allows testing SNS with LocalStack (no real X.509 signatures).
+- **CloudEvents headers forwarded** — `ce-*` headers stored with event and forwarded on delivery.
+- **Open Core model** — OSS base (this repo), paid Cloud version planned (UI, analytics, multi-tenant).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +409,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +423,29 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -1147,6 +1215,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,12 +1249,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -1198,6 +1292,12 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -1227,6 +1327,15 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -1384,6 +1493,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "qhook"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1422,19 +1537,23 @@ dependencies = [
  "clap",
  "hex",
  "hmac",
+ "pkcs1",
  "reqwest",
+ "rsa",
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha1",
  "sha2",
  "sqlx",
  "subtle",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tower-http",
  "tracing",
  "tracing-subscriber",
  "ulid",
+ "x509-parser",
 ]
 
 [[package]]
@@ -1624,6 +1743,15 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -1949,7 +2077,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2032,7 +2160,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "whoami",
 ]
@@ -2070,7 +2198,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "whoami",
 ]
@@ -2095,7 +2223,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "url",
 ]
@@ -2196,11 +2324,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2221,6 +2369,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -3033,6 +3212,23 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qhook"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 description = "Lightweight webhook receiver with queue and retry. SQS for webhooks."
 license = "Apache-2.0"
@@ -22,10 +22,14 @@ serde_yaml = "0.9"
 
 # Crypto
 hmac = "0.12"
-sha2 = "0.10"
+sha2 = { version = "0.10", features = ["oid"] }
 hex = "0.4"
 base64 = "0.22"
 subtle = "2"
+rsa = "0.9"
+sha1 = { version = "0.10", features = ["oid"] }
+pkcs1 = "0.7"
+x509-parser = "0.16"
 
 # CLI
 clap = { version = "4", features = ["derive"] }

--- a/KANBAN.md
+++ b/KANBAN.md
@@ -1,0 +1,55 @@
+# qhook Kanban
+
+## Done (v0.1)
+
+| Task | Priority |
+|------|----------|
+| Webhook receive + queue + retry | Very High |
+| Signature verification (GitHub/Stripe/Shopify/HMAC) | High |
+| Idempotency (JSONPath dedup key) | High |
+| Dead Letter Queue | High |
+| CLI commands (jobs list/retry, events list) | Low |
+| Docker image + Compose | High |
+| Deploy guides (AWS/Railway/Fly.io/Render) | Low |
+| lib.rs separation for Cloud version | Low |
+| Stripe checkout example app | Low |
+
+## Done (v0.2)
+
+| Task | Priority |
+|------|----------|
+| CloudEvents support (binary + structured) | High |
+| AWS SNS input + X.509 signature verification | High |
+| skip_verify option for testing | Low |
+| Unit tests (34 tests) | High |
+| E2E tests (14 + 8 SNS tests) | High |
+| devcontainer + LocalStack setup | Low |
+| Update README/docs for v0.2 features | High |
+
+## In Progress
+
+| Task | Priority |
+|------|----------|
+| (empty) | |
+
+## Todo (v0.3)
+
+| Task | Priority |
+|------|----------|
+| gRPC output support | High |
+| Prometheus metrics endpoint | High |
+| Rate limiting per handler | Low |
+| Batch delivery (group multiple events) | Low |
+
+## Backlog
+
+| Task | Priority |
+|------|----------|
+| GitHub Actions CI/CD | High |
+| Cloud: Web UI dashboard | High |
+| Cloud: Multi-tenant support | High |
+| Cloud: Event analytics | Low |
+| AWS EventBridge input | Low |
+| GCP Pub/Sub input | Low |
+| JSONPath-based event filtering | Low |
+| Payload transformation | Low |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 - **Webhook verification built in.** GitHub, Stripe, Shopify, and generic HMAC -- signature checks happen before your app ever sees the payload.
 - **Reliable delivery.** Exponential backoff retry with configurable limits. Dead Letter Queue for jobs that exhaust all attempts.
 - **Idempotency.** Configurable dedup key (JSONPath) prevents double-processing of the same event.
+- **CloudEvents native.** Automatically detects CloudEvents (binary and structured mode) and forwards `ce-*` headers to your handlers.
+- **AWS SNS ready.** Receive events from SNS topics with automatic subscription confirmation and X.509 signature verification.
 
 > See [docs/why-qhook.md](./docs/why-qhook.md) for a detailed before/after comparison.
 
@@ -117,6 +119,10 @@ sources:
   app:
     type: event                     # no verification, uses auth_token if set
 
+  my-sns:
+    type: sns                       # AWS SNS input (auto-confirms subscriptions)
+    # skip_verify: true             # skip X.509 verification (for LocalStack / testing)
+
 handlers:
   payment-success:
     source: stripe                  # must match a source name
@@ -132,6 +138,11 @@ handlers:
     source: github
     events: [push]
     url: http://deployer:4000/deploy
+
+  on-sns-notification:
+    source: my-sns
+    events: [order.created]
+    url: http://backend:3000/jobs/sns-order
 ```
 
 Generate a starter config:
@@ -235,13 +246,89 @@ Checks the `X-Webhook-Signature` header using HMAC-SHA256 (hex-encoded).
 
 All signature comparisons use constant-time equality to prevent timing attacks.
 
+## AWS SNS
+
+qhook can receive events from AWS SNS topics. It handles the full lifecycle automatically:
+
+1. **Subscription confirmation** -- when SNS sends a `SubscriptionConfirmation` message, qhook automatically confirms by fetching the `SubscribeURL`.
+2. **Message unwrapping** -- SNS wraps your payload in an envelope. qhook extracts the `Message` field and delivers only the actual payload to your handlers.
+3. **Signature verification** -- each SNS message is verified using the X.509 certificate from AWS (SHA1/SHA256).
+
+### Setup
+
+```yaml
+sources:
+  my-sns:
+    type: sns
+```
+
+Point your SNS subscription to `https://your-qhook-host/sns/my-sns`. The event type is extracted from the message payload (`type` field, `detail-type` for EventBridge, or the SNS `Subject`).
+
+### Testing with LocalStack
+
+For local development, use `skip_verify: true` to bypass X.509 signature verification:
+
+```yaml
+sources:
+  my-sns:
+    type: sns
+    skip_verify: true     # LocalStack does not sign messages
+```
+
+## CloudEvents
+
+qhook automatically detects and handles [CloudEvents](https://cloudevents.io/) in both content modes.
+
+### Binary mode
+
+CloudEvents metadata is sent as HTTP headers (`ce-type`, `ce-source`, `ce-id`, etc.). The body contains the event data directly.
+
+```bash
+curl -X POST http://localhost:8888/events/ignored \
+  -H "Content-Type: application/json" \
+  -H "ce-type: com.example.order.created" \
+  -H "ce-source: /shop" \
+  -H "ce-id: evt-001" \
+  -H "ce-specversion: 1.0" \
+  -d '{"orderId": "ord_123"}'
+```
+
+The `ce-type` header overrides the event type from the URL path.
+
+### Structured mode
+
+The entire CloudEvents envelope is sent as JSON with `Content-Type: application/cloudevents+json`.
+
+```bash
+curl -X POST http://localhost:8888/webhooks/my-source \
+  -H "Content-Type: application/cloudevents+json" \
+  -d '{
+    "specversion": "1.0",
+    "type": "com.example.order.created",
+    "source": "/shop",
+    "id": "evt-001",
+    "data": {"orderId": "ord_123"}
+  }'
+```
+
+The `type` field from the envelope is used as the event type.
+
+### Header forwarding
+
+All `ce-*` headers from the original event are automatically forwarded to your handlers on delivery, so your app can access CloudEvents metadata without parsing the payload.
+
 ## Architecture
 
 ```
-Webhook Provider          qhook                          Your App
-(GitHub, Stripe, ...)     +--------------------------+
+Webhook / SNS / Event     qhook                          Your App
+                          +--------------------------+
                           |                          |
   POST /webhooks/stripe ---> Verify signature        |
+  POST /sns/my-topic ------> Verify X.509 + unwrap   |
+  POST /events/order ------> Auth token check        |
+                          |   |                      |
+                          |   v                      |
+                          | Detect CloudEvents       |
                           |   |                      |
                           |   v                      |
                           | Store event (dedup)      |
@@ -251,7 +338,7 @@ Webhook Provider          qhook                          Your App
                           |   |                      |
                           |   v                      |
                           | Queue worker ------------>  POST http://backend/jobs/payment
-                          |   |                      |
+                          |   |                      |   (+ ce-* headers forwarded)
                           |   |-- success ----------->  mark completed
                           |   |-- failure (< max) -->  exponential backoff, retry
                           |   |-- failure (= max) -->  move to Dead Letter Queue
@@ -263,7 +350,8 @@ Webhook Provider          qhook                          Your App
 | Route | Purpose |
 |-------|---------|
 | `POST /webhooks/{source}` | Receive external webhooks (signature verified) |
-| `POST /events/{event_type}` | Receive internal events (bearer token auth) |
+| `POST /sns/{source}` | Receive AWS SNS messages (X.509 verified, auto-confirms subscriptions) |
+| `POST /events/{event_type}` | Receive internal events (bearer token auth, CloudEvents-aware) |
 | `GET /health` | Health check |
 
 ## Deployment

--- a/docs/why-qhook.md
+++ b/docs/why-qhook.md
@@ -241,6 +241,8 @@ Signature verification, idempotency, retry, DLQ -- all handled by qhook. Return 
 | **Event persistence** | Design your own DB schema | Auto-saved to SQLite/Postgres |
 | **Fan-out** | Manual dispatch logic | Define multiple handlers |
 | **Adding providers** | New endpoint + verification | Add a few lines to sources |
+| **AWS SNS** | Parse envelope, verify X.509, confirm subscription | `type: sns` -- one line |
+| **CloudEvents** | Parse headers/envelope, forward metadata | Automatic detection |
 | **External deps** | Redis/RabbitMQ, Celery, etc. | Single qhook binary |
 | **Monitoring** | Flower or custom UI | `qhook jobs` / `qhook events` CLI |
 | **Recovery** | Custom recovery procedures | `qhook jobs retry` |
@@ -270,6 +272,18 @@ sources:
 ```
 
 qhook absorbs the algorithm differences (Stripe's `t=...` format, GitHub's `sha256=...` format, Shopify's Base64 HMAC). Your app only receives verified payloads.
+
+### AWS SNS as an event source
+
+Receiving events from SNS requires handling subscription confirmation, envelope unwrapping, and X.509 certificate verification. With qhook, it's one line:
+
+```yaml
+sources:
+  notifications:
+    type: sns
+```
+
+qhook automatically confirms subscriptions, verifies message signatures, unwraps the SNS envelope, and delivers the actual message payload to your handlers.
 
 ### Fan-out to multiple services
 

--- a/examples/qhook.yaml
+++ b/examples/qhook.yaml
@@ -18,9 +18,20 @@ sources:
   app:
     type: event
 
+  # Uncomment to receive AWS SNS notifications
+  # my-sns:
+  #   type: sns
+  #   skip_verify: true    # set to false in production
+
 # Handlers - deliver received events to the specified URL
 handlers:
   order-webhook:
     source: app
     events: [order.created]
     url: http://localhost:3000/webhooks/orders
+
+  # Uncomment to handle SNS events
+  # on-sns:
+  #   source: my-sns
+  #   events: ["*"]
+  #   url: http://localhost:3000/webhooks/sns

--- a/src/api.rs
+++ b/src/api.rs
@@ -18,13 +18,19 @@ use crate::queue::Worker;
 pub struct AppState {
     pub config: Config,
     pub db: Arc<Database>,
+    pub http: reqwest::Client,
 }
 
 impl AppState {
     pub fn new(config: Config, db: Database) -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+            .expect("Failed to build HTTP client");
         Self {
             config,
             db: Arc::new(db),
+            http,
         }
     }
 }
@@ -35,12 +41,16 @@ pub async fn serve(state: AppState) -> Result<()> {
     let port = state.config.server.port;
     let shared = Arc::new(state);
 
-    // Print registered webhook endpoints
+    // Print registered endpoints
     for (name, source) in &shared.config.sources {
-        if source.source_type == "webhook" {
-            tracing::info!(
-                "  POST http://localhost:{port}/webhooks/{name}",
-            );
+        match source.source_type.as_str() {
+            "webhook" => {
+                tracing::info!("  POST http://localhost:{port}/webhooks/{name}");
+            }
+            "sns" => {
+                tracing::info!("  POST http://localhost:{port}/sns/{name}");
+            }
+            _ => {}
         }
     }
 
@@ -53,6 +63,7 @@ pub async fn serve(state: AppState) -> Result<()> {
     let app = Router::new()
         .route("/webhooks/{source}", post(handle_webhook))
         .route("/events/{event_type}", post(handle_event))
+        .route("/sns/{source}", post(handle_sns))
         .route("/health", axum::routing::get(|| async { "ok" }))
         .with_state(shared);
 
@@ -102,8 +113,8 @@ async fn handle_webhook(
         Err(_) => return (StatusCode::BAD_REQUEST, "Invalid UTF-8".to_string()),
     };
 
-    // Extract event type from payload
-    let event_type = extract_event_type(&source_name, &payload_str);
+    // Extract event type (CloudEvents-aware)
+    let event_type = extract_event_type(&source_name, &payload_str, &headers);
 
     // Process event
     match process_event(&state, &source_name, &event_type, &payload_str, &headers).await {
@@ -148,6 +159,13 @@ async fn handle_event(
         Err(_) => return (StatusCode::BAD_REQUEST, "Invalid UTF-8".to_string()),
     };
 
+    // CloudEvents ce-type header overrides URL path event type
+    let event_type = if let Some(ce_type) = headers.get("ce-type").and_then(|v| v.to_str().ok()) {
+        ce_type.to_string()
+    } else {
+        event_type
+    };
+
     match process_event(&state, "app", &event_type, &payload_str, &headers).await {
         Ok(_) => (StatusCode::ACCEPTED, "Event accepted".to_string()),
         Err(e) => {
@@ -156,6 +174,122 @@ async fn handle_event(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Internal error".to_string(),
             )
+        }
+    }
+}
+
+async fn handle_sns(
+    State(state): State<SharedState>,
+    Path(source_name): Path<String>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> impl IntoResponse {
+    // Find source config
+    let source = match state.config.sources.get(&source_name) {
+        Some(s) if s.source_type == "sns" => s,
+        _ => return (StatusCode::NOT_FOUND, "Unknown source".to_string()),
+    };
+
+    let body_str = match String::from_utf8(body.to_vec()) {
+        Ok(s) => s,
+        Err(_) => return (StatusCode::BAD_REQUEST, "Invalid UTF-8".to_string()),
+    };
+
+    // Parse SNS message
+    let sns_msg: crate::verify::SnsMessage = match serde_json::from_str(&body_str) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to parse SNS message");
+            return (StatusCode::BAD_REQUEST, "Invalid SNS message".to_string());
+        }
+    };
+
+    // Verify SNS signature (can be skipped for LocalStack / testing)
+    if source.skip_verify {
+        tracing::debug!(source = source_name, "SNS signature verification skipped");
+    } else {
+        match crate::verify::verify_sns_message(&sns_msg, &state.http).await {
+            Ok(true) => {}
+            Ok(false) => {
+                tracing::warn!(source = source_name, "SNS signature verification failed");
+                return (StatusCode::UNAUTHORIZED, "Invalid signature".to_string());
+            }
+            Err(e) => {
+                tracing::error!(source = source_name, error = %e, "SNS verification error");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Verification error".to_string(),
+                );
+            }
+        }
+    }
+
+    // Handle message type
+    match sns_msg.message_type.as_str() {
+        "SubscriptionConfirmation" => {
+            if let Some(ref subscribe_url) = sns_msg.subscribe_url {
+                tracing::info!(
+                    source = source_name,
+                    topic = sns_msg.topic_arn,
+                    "Confirming SNS subscription"
+                );
+                match state.http.get(subscribe_url).send().await {
+                    Ok(resp) if resp.status().is_success() => {
+                        tracing::info!(source = source_name, "SNS subscription confirmed");
+                        (StatusCode::OK, "Subscription confirmed".to_string())
+                    }
+                    Ok(resp) => {
+                        tracing::error!(
+                            source = source_name,
+                            status = resp.status().as_u16(),
+                            "Failed to confirm SNS subscription"
+                        );
+                        (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "Subscription confirmation failed".to_string(),
+                        )
+                    }
+                    Err(e) => {
+                        tracing::error!(source = source_name, error = %e, "Failed to confirm SNS subscription");
+                        (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "Subscription confirmation failed".to_string(),
+                        )
+                    }
+                }
+            } else {
+                (StatusCode::BAD_REQUEST, "Missing SubscribeURL".to_string())
+            }
+        }
+        "Notification" => {
+            // Unwrap the SNS envelope: use Message field as the actual payload
+            let payload = &sns_msg.message;
+            let event_type = extract_sns_event_type(payload, sns_msg.subject.as_deref());
+
+            match process_event(&state, &source_name, &event_type, payload, &headers).await {
+                Ok(created) => {
+                    if created {
+                        (StatusCode::OK, "Event received".to_string())
+                    } else {
+                        (StatusCode::OK, "Duplicate event ignored".to_string())
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, "Failed to process SNS event");
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "Internal error".to_string(),
+                    )
+                }
+            }
+        }
+        "UnsubscribeConfirmation" => {
+            tracing::info!(source = source_name, "SNS unsubscribe confirmation received");
+            (StatusCode::OK, "Unsubscribe acknowledged".to_string())
+        }
+        other => {
+            tracing::warn!(source = source_name, message_type = other, "Unknown SNS message type");
+            (StatusCode::BAD_REQUEST, "Unknown message type".to_string())
         }
     }
 }
@@ -238,7 +372,23 @@ async fn process_event(
     Ok(true)
 }
 
-fn extract_event_type(source: &str, payload: &str) -> String {
+fn extract_event_type(source: &str, payload: &str, headers: &HeaderMap) -> String {
+    // CloudEvents binary mode: ce-type header takes precedence
+    if let Some(ce_type) = headers.get("ce-type").and_then(|v| v.to_str().ok()) {
+        return ce_type.to_string();
+    }
+
+    // CloudEvents structured mode: application/cloudevents+json
+    if let Some(ct) = headers.get("content-type").and_then(|v| v.to_str().ok()) {
+        if ct.contains("application/cloudevents+json") {
+            let json: Value = serde_json::from_str(payload).unwrap_or(Value::Null);
+            if let Some(ce_type) = json.get("type").and_then(|v| v.as_str()) {
+                return ce_type.to_string();
+            }
+        }
+    }
+
+    // Provider-specific extraction
     let json: Value = serde_json::from_str(payload).unwrap_or(Value::Null);
 
     match source {
@@ -262,6 +412,34 @@ fn extract_event_type(source: &str, payload: &str) -> String {
             .to_string(),
         _ => "event".to_string(),
     }
+}
+
+fn extract_sns_event_type(message: &str, subject: Option<&str>) -> String {
+    if let Ok(json) = serde_json::from_str::<Value>(message) {
+        // CloudEvents structured mode
+        if json.get("specversion").is_some() {
+            if let Some(t) = json.get("type").and_then(|v| v.as_str()) {
+                return t.to_string();
+            }
+        }
+        // Generic type field
+        if let Some(t) = json.get("type").and_then(|v| v.as_str()) {
+            return t.to_string();
+        }
+        // AWS EventBridge detail-type (often forwarded via SNS)
+        if let Some(t) = json.get("detail-type").and_then(|v| v.as_str()) {
+            return t.to_string();
+        }
+    }
+
+    // Subject as event type
+    if let Some(s) = subject {
+        if !s.is_empty() {
+            return s.to_string();
+        }
+    }
+
+    "sns.notification".to_string()
 }
 
 fn event_matches(pattern: &str, event_type: &str) -> bool {
@@ -299,4 +477,184 @@ fn serialize_headers(headers: &HeaderMap) -> String {
         .collect();
 
     serde_json::to_string(&map).unwrap_or_else(|_| "{}".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderMap;
+
+    // --- CloudEvents event type extraction ---
+
+    #[test]
+    fn test_cloudevents_binary_mode() {
+        let mut headers = HeaderMap::new();
+        headers.insert("ce-type", "com.example.order.created".parse().unwrap());
+        headers.insert("ce-specversion", "1.0".parse().unwrap());
+
+        let result = extract_event_type("my-source", "{}", &headers);
+        assert_eq!(result, "com.example.order.created");
+    }
+
+    #[test]
+    fn test_cloudevents_structured_mode() {
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", "application/cloudevents+json".parse().unwrap());
+
+        let payload = r#"{
+            "specversion": "1.0",
+            "type": "com.example.user.signup",
+            "source": "/myapp",
+            "id": "abc-123",
+            "data": {"name": "Alice"}
+        }"#;
+
+        let result = extract_event_type("my-source", payload, &headers);
+        assert_eq!(result, "com.example.user.signup");
+    }
+
+    #[test]
+    fn test_cloudevents_binary_takes_precedence() {
+        let mut headers = HeaderMap::new();
+        headers.insert("ce-type", "from.header".parse().unwrap());
+        headers.insert("content-type", "application/cloudevents+json".parse().unwrap());
+
+        let payload = r#"{"type": "from.body"}"#;
+        let result = extract_event_type("source", payload, &headers);
+        assert_eq!(result, "from.header");
+    }
+
+    // --- Provider-specific event type extraction ---
+
+    #[test]
+    fn test_stripe_event_type() {
+        let headers = HeaderMap::new();
+        let payload = r#"{"type": "invoice.paid", "id": "evt_123"}"#;
+        assert_eq!(extract_event_type("stripe", payload, &headers), "invoice.paid");
+    }
+
+    #[test]
+    fn test_github_event_type() {
+        let headers = HeaderMap::new();
+        let payload = r#"{"action": "opened", "number": 1}"#;
+        assert_eq!(extract_event_type("github", payload, &headers), "opened");
+    }
+
+    #[test]
+    fn test_shopify_event_type() {
+        let headers = HeaderMap::new();
+        let payload = r#"{"topic": "orders/create"}"#;
+        assert_eq!(extract_event_type("shopify", payload, &headers), "orders/create");
+    }
+
+    #[test]
+    fn test_unknown_source_event_type() {
+        let headers = HeaderMap::new();
+        assert_eq!(extract_event_type("custom", "{}", &headers), "event");
+    }
+
+    // --- SNS event type extraction ---
+
+    #[test]
+    fn test_sns_event_type_from_json_type() {
+        let message = r#"{"type": "order.created", "data": {}}"#;
+        assert_eq!(extract_sns_event_type(message, None), "order.created");
+    }
+
+    #[test]
+    fn test_sns_event_type_from_cloudevents() {
+        let message = r#"{"specversion": "1.0", "type": "com.example.event", "source": "/"}"#;
+        assert_eq!(extract_sns_event_type(message, None), "com.example.event");
+    }
+
+    #[test]
+    fn test_sns_event_type_from_eventbridge() {
+        let message = r#"{"detail-type": "EC2 Instance State-change", "source": "aws.ec2"}"#;
+        assert_eq!(
+            extract_sns_event_type(message, None),
+            "EC2 Instance State-change"
+        );
+    }
+
+    #[test]
+    fn test_sns_event_type_from_subject() {
+        let message = "plain text message";
+        assert_eq!(
+            extract_sns_event_type(message, Some("my-subject")),
+            "my-subject"
+        );
+    }
+
+    #[test]
+    fn test_sns_event_type_fallback() {
+        assert_eq!(extract_sns_event_type("not json", None), "sns.notification");
+    }
+
+    // --- Event matching ---
+
+    #[test]
+    fn test_event_matches_exact() {
+        assert!(event_matches("order.created", "order.created"));
+        assert!(!event_matches("order.created", "order.updated"));
+    }
+
+    #[test]
+    fn test_event_matches_wildcard() {
+        assert!(event_matches("*", "anything"));
+        assert!(event_matches("*", ""));
+    }
+
+    #[test]
+    fn test_event_matches_prefix() {
+        assert!(event_matches("order.*", "order.created"));
+        assert!(event_matches("order.*", "order.updated"));
+        assert!(!event_matches("order.*", "user.created"));
+    }
+
+    // --- JSON path extraction ---
+
+    #[test]
+    fn test_json_path_simple() {
+        let payload = r#"{"id": "evt_123"}"#;
+        assert_eq!(extract_json_path(payload, "$.id"), Some("evt_123".into()));
+    }
+
+    #[test]
+    fn test_json_path_nested() {
+        let payload = r#"{"data": {"order": {"id": "ord_456"}}}"#;
+        assert_eq!(
+            extract_json_path(payload, "$.data.order.id"),
+            Some("ord_456".into())
+        );
+    }
+
+    #[test]
+    fn test_json_path_missing() {
+        let payload = r#"{"id": "evt_123"}"#;
+        assert_eq!(extract_json_path(payload, "$.missing"), None);
+    }
+
+    #[test]
+    fn test_json_path_without_dollar_prefix() {
+        let payload = r#"{"id": "evt_123"}"#;
+        assert_eq!(extract_json_path(payload, "id"), Some("evt_123".into()));
+    }
+
+    // --- Header serialization ---
+
+    #[test]
+    fn test_serialize_headers_includes_ce_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert("ce-type", "test.event".parse().unwrap());
+        headers.insert("ce-source", "/myapp".parse().unwrap());
+        headers.insert("content-type", "application/json".parse().unwrap());
+
+        let json = serialize_headers(&headers);
+        let map: std::collections::HashMap<String, String> =
+            serde_json::from_str(&json).unwrap();
+
+        assert_eq!(map.get("ce-type").unwrap(), "test.event");
+        assert_eq!(map.get("ce-source").unwrap(), "/myapp");
+        assert_eq!(map.get("content-type").unwrap(), "application/json");
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -123,6 +123,8 @@ pub struct SourceConfig {
     pub source_type: String,
     pub verify: Option<String>,
     pub secret: Option<String>,
+    #[serde(default)]
+    pub skip_verify: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/db.rs
+++ b/src/db.rs
@@ -317,6 +317,15 @@ impl Database {
         Ok(row.0)
     }
 
+    pub async fn get_event_headers(&self, event_id: &str) -> Result<Option<String>> {
+        let row: (Option<String>,) = sqlx::query_as("SELECT headers FROM events WHERE id = $1")
+            .bind(event_id)
+            .fetch_one(&self.pool)
+            .await?;
+
+        Ok(row.0)
+    }
+
     pub async fn list_jobs(&self, status: Option<&str>, limit: i32) -> Result<Vec<JobRow>> {
         let rows = if let Some(status) = status {
             sqlx::query_as::<_, JobRow>(

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -114,8 +114,9 @@ impl Worker {
 
     async fn deliver(&self, job: &crate::db::JobRow) -> Result<u16> {
         let payload = self.db.get_event_payload(&job.event_id).await?;
+        let headers_json = self.db.get_event_headers(&job.event_id).await?;
 
-        let response = self
+        let mut request = self
             .http
             .post(&job.url)
             .header("Content-Type", "application/json")
@@ -125,10 +126,20 @@ impl Worker {
             .header(
                 "X-Qhook-Attempt",
                 (job.attempt + 1).to_string(),
-            )
-            .body(payload)
-            .send()
-            .await?;
+            );
+
+        // Forward CloudEvents headers from the original event
+        if let Some(ref hj) = headers_json {
+            if let Ok(headers) = serde_json::from_str::<std::collections::HashMap<String, String>>(hj) {
+                for (key, value) in &headers {
+                    if key.starts_with("ce-") {
+                        request = request.header(key.as_str(), value.as_str());
+                    }
+                }
+            }
+        }
+
+        let response = request.body(payload).send().await?;
 
         Ok(response.status().as_u16())
     }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -128,3 +128,383 @@ fn constant_time_eq(a: &str, b: &str) -> bool {
     }
     a.as_bytes().ct_eq(b.as_bytes()).into()
 }
+
+// --- SNS signature verification ---
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct SnsMessage {
+    #[serde(rename = "Type")]
+    pub message_type: String,
+    #[serde(rename = "MessageId")]
+    pub message_id: String,
+    #[serde(rename = "Message")]
+    pub message: String,
+    #[serde(rename = "Timestamp")]
+    pub timestamp: String,
+    #[serde(rename = "TopicArn")]
+    pub topic_arn: String,
+    #[serde(rename = "Signature")]
+    pub signature: String,
+    #[serde(rename = "SigningCertURL")]
+    pub signing_cert_url: String,
+    #[serde(rename = "SignatureVersion")]
+    pub signature_version: String,
+    #[serde(rename = "Subject", default)]
+    pub subject: Option<String>,
+    #[serde(rename = "SubscribeURL", default)]
+    pub subscribe_url: Option<String>,
+    #[serde(rename = "Token", default)]
+    pub token: Option<String>,
+    #[serde(rename = "UnsubscribeURL", default)]
+    pub unsubscribe_url: Option<String>,
+}
+
+pub async fn verify_sns_message(
+    msg: &SnsMessage,
+    http: &reqwest::Client,
+) -> Result<bool> {
+    let cert_url = &msg.signing_cert_url;
+
+    // Validate the signing cert URL is from SNS
+    if !is_valid_sns_cert_url(cert_url) {
+        tracing::warn!(url = cert_url, "Invalid SNS SigningCertURL");
+        return Ok(false);
+    }
+
+    // Fetch the signing certificate
+    let pem_data = http
+        .get(cert_url)
+        .send()
+        .await?
+        .bytes()
+        .await?;
+
+    // Parse X.509 certificate
+    let (_, pem) = x509_parser::pem::parse_x509_pem(&pem_data)
+        .map_err(|e| anyhow::anyhow!("PEM parse error: {:?}", e))?;
+    let (_, cert) = x509_parser::parse_x509_certificate(&pem.contents)
+        .map_err(|e| anyhow::anyhow!("X.509 parse error: {:?}", e))?;
+
+    // Extract RSA public key (PKCS#1 DER from SPKI)
+    use pkcs1::DecodeRsaPublicKey;
+    let key_data = cert.tbs_certificate.subject_pki.subject_public_key.data;
+    let public_key = rsa::RsaPublicKey::from_pkcs1_der(&key_data)
+        .map_err(|e| anyhow::anyhow!("RSA key parse error: {e}"))?;
+
+    // Build the string to sign
+    let string_to_sign = build_sns_string_to_sign(msg);
+
+    // Decode the base64 signature
+    use base64::Engine;
+    let sig_bytes = base64::engine::general_purpose::STANDARD.decode(&msg.signature)?;
+
+    // Verify based on SignatureVersion
+    use rsa::pkcs1v15::{Signature, VerifyingKey};
+    use rsa::signature::Verifier;
+
+    let sig = Signature::try_from(sig_bytes.as_slice())
+        .map_err(|e| anyhow::anyhow!("Invalid signature: {e}"))?;
+
+    let valid = match msg.signature_version.as_str() {
+        "1" => {
+            let vk = VerifyingKey::<sha1::Sha1>::new(public_key);
+            vk.verify(string_to_sign.as_bytes(), &sig).is_ok()
+        }
+        "2" => {
+            let vk = VerifyingKey::<sha2::Sha256>::new(public_key);
+            vk.verify(string_to_sign.as_bytes(), &sig).is_ok()
+        }
+        _ => {
+            tracing::warn!(version = msg.signature_version, "Unknown SNS SignatureVersion");
+            false
+        }
+    };
+
+    Ok(valid)
+}
+
+pub fn is_valid_sns_cert_url(url: &str) -> bool {
+    // Must be HTTPS from an SNS endpoint
+    if !url.starts_with("https://sns.") {
+        return false;
+    }
+    // Must be from amazonaws.com
+    if let Some(host_start) = url.strip_prefix("https://") {
+        if let Some(path_start) = host_start.find('/') {
+            let host = &host_start[..path_start];
+            return host.ends_with(".amazonaws.com");
+        }
+    }
+    false
+}
+
+pub fn build_sns_string_to_sign(msg: &SnsMessage) -> String {
+    let mut lines = String::new();
+
+    match msg.message_type.as_str() {
+        "Notification" => {
+            lines.push_str("Message\n");
+            lines.push_str(&msg.message);
+            lines.push('\n');
+            lines.push_str("MessageId\n");
+            lines.push_str(&msg.message_id);
+            lines.push('\n');
+            if let Some(ref subject) = msg.subject {
+                lines.push_str("Subject\n");
+                lines.push_str(subject);
+                lines.push('\n');
+            }
+            lines.push_str("Timestamp\n");
+            lines.push_str(&msg.timestamp);
+            lines.push('\n');
+            lines.push_str("TopicArn\n");
+            lines.push_str(&msg.topic_arn);
+            lines.push('\n');
+            lines.push_str("Type\n");
+            lines.push_str(&msg.message_type);
+            lines.push('\n');
+        }
+        "SubscriptionConfirmation" | "UnsubscribeConfirmation" => {
+            lines.push_str("Message\n");
+            lines.push_str(&msg.message);
+            lines.push('\n');
+            lines.push_str("MessageId\n");
+            lines.push_str(&msg.message_id);
+            lines.push('\n');
+            if let Some(ref url) = msg.subscribe_url {
+                lines.push_str("SubscribeURL\n");
+                lines.push_str(url);
+                lines.push('\n');
+            }
+            lines.push_str("Timestamp\n");
+            lines.push_str(&msg.timestamp);
+            lines.push('\n');
+            if let Some(ref token) = msg.token {
+                lines.push_str("Token\n");
+                lines.push_str(token);
+                lines.push('\n');
+            }
+            lines.push_str("TopicArn\n");
+            lines.push_str(&msg.topic_arn);
+            lines.push('\n');
+            lines.push_str("Type\n");
+            lines.push_str(&msg.message_type);
+            lines.push('\n');
+        }
+        _ => {}
+    }
+
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderMap;
+
+    // --- HMAC verification ---
+
+    #[test]
+    fn test_github_signature_valid() {
+        let secret = "mysecret";
+        let payload = b"hello world";
+        let expected = compute_hmac_sha256_hex(secret.as_bytes(), payload);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-Hub-Signature-256",
+            format!("sha256={expected}").parse().unwrap(),
+        );
+
+        assert!(verify_github(secret, payload, &headers).unwrap());
+    }
+
+    #[test]
+    fn test_github_signature_invalid() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-Hub-Signature-256",
+            "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+                .parse()
+                .unwrap(),
+        );
+        assert!(!verify_github("secret", b"payload", &headers).unwrap());
+    }
+
+    #[test]
+    fn test_github_signature_missing() {
+        let headers = HeaderMap::new();
+        assert!(!verify_github("secret", b"payload", &headers).unwrap());
+    }
+
+    #[test]
+    fn test_stripe_signature_valid() {
+        let secret = "whsec_test";
+        let payload = b"{\"id\":\"evt_123\"}";
+        let timestamp = "1234567890";
+        let signed = format!("{timestamp}.{}", String::from_utf8_lossy(payload));
+        let sig = compute_hmac_sha256_hex(secret.as_bytes(), signed.as_bytes());
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "Stripe-Signature",
+            format!("t={timestamp},v1={sig}").parse().unwrap(),
+        );
+
+        assert!(verify_stripe(secret, payload, &headers).unwrap());
+    }
+
+    #[test]
+    fn test_shopify_signature_valid() {
+        let secret = "shopify_secret";
+        let payload = b"{\"topic\":\"orders/create\"}";
+        let expected = compute_hmac_sha256_base64(secret.as_bytes(), payload);
+
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Shopify-Hmac-SHA256", expected.parse().unwrap());
+
+        assert!(verify_shopify(secret, payload, &headers).unwrap());
+    }
+
+    #[test]
+    fn test_custom_hmac_valid() {
+        let secret = "my_secret";
+        let payload = b"data";
+        let expected = compute_hmac_sha256_hex(secret.as_bytes(), payload);
+
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Webhook-Signature", expected.parse().unwrap());
+
+        assert!(verify_custom_hmac(secret, payload, &headers).unwrap());
+    }
+
+    #[test]
+    fn test_verify_signature_unknown_provider() {
+        let headers = HeaderMap::new();
+        assert!(verify_signature("unknown", "secret", b"data", &headers).is_err());
+    }
+
+    // --- Constant-time comparison ---
+
+    #[test]
+    fn test_constant_time_eq() {
+        assert!(constant_time_eq("abc", "abc"));
+        assert!(!constant_time_eq("abc", "abd"));
+        assert!(!constant_time_eq("abc", "abcd"));
+    }
+
+    // --- SNS cert URL validation ---
+
+    #[test]
+    fn test_sns_cert_url_valid() {
+        assert!(is_valid_sns_cert_url(
+            "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-abc123.pem"
+        ));
+        assert!(is_valid_sns_cert_url(
+            "https://sns.ap-northeast-1.amazonaws.com/cert.pem"
+        ));
+    }
+
+    #[test]
+    fn test_sns_cert_url_invalid() {
+        assert!(!is_valid_sns_cert_url("http://sns.us-east-1.amazonaws.com/cert.pem")); // http
+        assert!(!is_valid_sns_cert_url("https://evil.com/cert.pem")); // wrong domain
+        assert!(!is_valid_sns_cert_url("https://sns.us-east-1.evil.com/cert.pem")); // spoofed
+        assert!(!is_valid_sns_cert_url("https://amazonaws.com/cert.pem")); // missing sns prefix
+    }
+
+    // --- SNS string to sign ---
+
+    #[test]
+    fn test_sns_notification_string_to_sign() {
+        let msg = SnsMessage {
+            message_type: "Notification".into(),
+            message_id: "msg-123".into(),
+            message: "Hello".into(),
+            timestamp: "2024-01-01T00:00:00.000Z".into(),
+            topic_arn: "arn:aws:sns:us-east-1:123456:my-topic".into(),
+            signature: String::new(),
+            signing_cert_url: String::new(),
+            signature_version: "1".into(),
+            subject: None,
+            subscribe_url: None,
+            token: None,
+            unsubscribe_url: None,
+        };
+
+        let result = build_sns_string_to_sign(&msg);
+        assert_eq!(
+            result,
+            "Message\nHello\nMessageId\nmsg-123\nTimestamp\n2024-01-01T00:00:00.000Z\nTopicArn\narn:aws:sns:us-east-1:123456:my-topic\nType\nNotification\n"
+        );
+    }
+
+    #[test]
+    fn test_sns_notification_with_subject() {
+        let msg = SnsMessage {
+            message_type: "Notification".into(),
+            message_id: "msg-456".into(),
+            message: "Body".into(),
+            timestamp: "2024-01-01T00:00:00.000Z".into(),
+            topic_arn: "arn:aws:sns:us-east-1:123456:topic".into(),
+            signature: String::new(),
+            signing_cert_url: String::new(),
+            signature_version: "1".into(),
+            subject: Some("My Subject".into()),
+            subscribe_url: None,
+            token: None,
+            unsubscribe_url: None,
+        };
+
+        let result = build_sns_string_to_sign(&msg);
+        assert!(result.contains("Subject\nMy Subject\n"));
+    }
+
+    #[test]
+    fn test_sns_subscription_confirmation_string_to_sign() {
+        let msg = SnsMessage {
+            message_type: "SubscriptionConfirmation".into(),
+            message_id: "msg-789".into(),
+            message: "You have chosen to subscribe".into(),
+            timestamp: "2024-01-01T00:00:00.000Z".into(),
+            topic_arn: "arn:aws:sns:us-east-1:123456:topic".into(),
+            signature: String::new(),
+            signing_cert_url: String::new(),
+            signature_version: "1".into(),
+            subject: None,
+            subscribe_url: Some("https://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription".into()),
+            token: Some("token-abc".into()),
+            unsubscribe_url: None,
+        };
+
+        let result = build_sns_string_to_sign(&msg);
+        assert!(result.contains("SubscribeURL\nhttps://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription\n"));
+        assert!(result.contains("Token\ntoken-abc\n"));
+        assert!(result.contains("Type\nSubscriptionConfirmation\n"));
+    }
+
+    // --- SNS message parsing ---
+
+    #[test]
+    fn test_sns_message_deserialization() {
+        let json = r#"{
+            "Type": "Notification",
+            "MessageId": "id-123",
+            "TopicArn": "arn:aws:sns:us-east-1:123:topic",
+            "Subject": "test",
+            "Message": "{\"key\":\"value\"}",
+            "Timestamp": "2024-01-01T00:00:00.000Z",
+            "SignatureVersion": "1",
+            "Signature": "base64sig==",
+            "SigningCertURL": "https://sns.us-east-1.amazonaws.com/cert.pem"
+        }"#;
+
+        let msg: SnsMessage = serde_json::from_str(json).unwrap();
+        assert_eq!(msg.message_type, "Notification");
+        assert_eq!(msg.message_id, "id-123");
+        assert_eq!(msg.subject, Some("test".into()));
+        assert_eq!(msg.message, "{\"key\":\"value\"}");
+    }
+}

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -236,6 +236,63 @@ COUNT=$(curl -s --max-time 3 http://127.0.0.1:19004/count 2>/dev/null || echo "0
 
 ########################################
 echo ""
+echo "=== Test 6: CloudEvents binary mode ==="
+########################################
+
+start_mock 19005
+
+cat > /tmp/e2e_qhook_6.yaml <<'EOF'
+database:
+  driver: sqlite
+  url: "sqlite:/tmp/e2e_qhook_6.db?mode=rwc"
+server:
+  port: 19106
+sources:
+  app:
+    type: event
+handlers:
+  on-ce:
+    source: app
+    events: [com.example.order.created]
+    url: http://127.0.0.1:19005/jobs/ce
+EOF
+
+start_qhook /tmp/e2e_qhook_6.yaml
+
+# CloudEvents binary mode: event type from ce-type header (overrides URL path)
+HTTP_CODE=$(curl -s --max-time 3 -o /dev/null -w "%{http_code}" \
+    -X POST http://127.0.0.1:19106/events/ignored.by.header \
+    -H "Content-Type: application/json" \
+    -H "ce-type: com.example.order.created" \
+    -H "ce-source: /myapp" \
+    -H "ce-id: evt-ce-001" \
+    -H "ce-specversion: 1.0" \
+    -d '{"orderId": "ord_ce_1"}')
+
+[ "$HTTP_CODE" = "202" ] && pass "CloudEvents binary mode accepted (202)" || fail "CE binary" "got $HTTP_CODE"
+
+sleep 2
+
+COUNT=$(curl -s --max-time 3 http://127.0.0.1:19005/count 2>/dev/null || echo "0")
+[ "$COUNT" -ge 1 ] 2>/dev/null && pass "CloudEvents event matched handler (count=$COUNT)" || fail "CE match" "count=$COUNT"
+
+# Check that ce-* headers are forwarded
+RECEIVED=$(curl -s --max-time 3 http://127.0.0.1:19005/received 2>/dev/null || echo "[]")
+HAS_CE=$(echo "$RECEIVED" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+if d:
+    h = d[0].get('headers', {})
+    has_type = any('ce-type' in k.lower() for k in h)
+    has_source = any('ce-source' in k.lower() for k in h)
+    print('yes' if has_type and has_source else 'no')
+else:
+    print('no')
+" 2>/dev/null || echo "no")
+[ "$HAS_CE" = "yes" ] && pass "CloudEvents headers forwarded" || fail "CE headers" "ce-type/ce-source not found"
+
+########################################
+echo ""
 echo "==============================="
 echo -e "Results: ${GREEN}${PASS} passed${NC}, ${RED}${FAIL} failed${NC}"
 echo "==============================="

--- a/tests/e2e_sns.sh
+++ b/tests/e2e_sns.sh
@@ -1,0 +1,229 @@
+#!/bin/bash
+# SNS integration test using LocalStack
+# Usage: ./tests/e2e_sns.sh
+# Requires: LocalStack running on $LOCALSTACK_ENDPOINT (default: http://localhost:4566)
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+LOCALSTACK=${LOCALSTACK_ENDPOINT:-http://localhost:4566}
+QHOOK_PORT=19201
+MOCK_PORT=19202
+
+PASS=0
+FAIL=0
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+pass() { echo -e "  ${GREEN}PASS${NC}: $1"; PASS=$((PASS+1)); }
+fail() { echo -e "  ${RED}FAIL${NC}: $1 — $2"; FAIL=$((FAIL+1)); }
+
+PIDS=()
+cleanup() {
+    for pid in "${PIDS[@]}"; do
+        kill "$pid" 2>/dev/null || true
+    done
+    wait 2>/dev/null || true
+    rm -f /tmp/e2e_sns_*.yaml /tmp/e2e_sns_*.db
+}
+trap cleanup EXIT
+
+# Check LocalStack is running
+echo "Checking LocalStack at $LOCALSTACK ..."
+if ! curl -sf "$LOCALSTACK/_localstack/health" > /dev/null 2>&1; then
+    echo "ERROR: LocalStack is not running at $LOCALSTACK"
+    echo "Start it with: docker run -d -p 4566:4566 -e SERVICES=sns localstack/localstack:3"
+    exit 1
+fi
+echo "LocalStack is ready."
+
+echo "Building qhook..."
+cargo build --quiet 2>&1 | grep -v warning || true
+
+# Start mock server
+python3 "$SCRIPT_DIR/mock_server.py" $MOCK_PORT &
+PIDS+=($!)
+sleep 0.3
+
+# Create qhook config with SNS source (skip_verify for LocalStack)
+cat > /tmp/e2e_sns_1.yaml <<EOF
+database:
+  driver: sqlite
+  url: "sqlite:/tmp/e2e_sns_1.db?mode=rwc"
+server:
+  port: $QHOOK_PORT
+sources:
+  my-sns:
+    type: sns
+    skip_verify: true
+handlers:
+  on-sns-event:
+    source: my-sns
+    events: ["*"]
+    url: http://127.0.0.1:$MOCK_PORT/jobs/sns
+    retry: { max: 3 }
+EOF
+
+# Start qhook
+./target/debug/qhook start --config /tmp/e2e_sns_1.yaml 2>/dev/null &
+PIDS+=($!)
+sleep 1
+
+########################################
+echo ""
+echo "=== Test 1: SNS Subscription Confirmation ==="
+########################################
+
+# Create SNS topic
+TOPIC_ARN=$(aws --endpoint-url "$LOCALSTACK" sns create-topic --name qhook-test --query 'TopicArn' --output text 2>/dev/null)
+echo "  Topic: $TOPIC_ARN"
+
+# Determine how Docker containers reach the host
+if [ "$(uname)" = "Darwin" ]; then
+    HOST_FROM_DOCKER="host.docker.internal"
+else
+    HOST_FROM_DOCKER="172.17.0.1"  # Default Docker bridge on Linux
+fi
+
+# Subscribe qhook to the topic (LocalStack sends SubscriptionConfirmation automatically)
+SUB_ARN=$(aws --endpoint-url "$LOCALSTACK" sns subscribe \
+    --topic-arn "$TOPIC_ARN" \
+    --protocol http \
+    --notification-endpoint "http://${HOST_FROM_DOCKER}:$QHOOK_PORT/sns/my-sns" \
+    --query 'SubscriptionArn' --output text 2>/dev/null || echo "pending")
+
+sleep 2
+
+# Check if subscription was confirmed
+if [ "$SUB_ARN" != "pending" ] && [ -n "$SUB_ARN" ]; then
+    pass "SNS subscription confirmed (arn=$SUB_ARN)"
+else
+    # LocalStack may auto-confirm; check via list-subscriptions
+    CONFIRMED=$(aws --endpoint-url "$LOCALSTACK" sns list-subscriptions-by-topic \
+        --topic-arn "$TOPIC_ARN" --query 'Subscriptions[0].SubscriptionArn' --output text 2>/dev/null || echo "none")
+    if [ "$CONFIRMED" != "PendingConfirmation" ] && [ "$CONFIRMED" != "none" ]; then
+        pass "SNS subscription confirmed (via list)"
+    else
+        fail "SNS subscription" "arn=$SUB_ARN, status=$CONFIRMED"
+    fi
+fi
+
+########################################
+echo ""
+echo "=== Test 2: SNS Notification → qhook → delivery ==="
+########################################
+
+# Reset mock counter
+curl -sf http://127.0.0.1:$MOCK_PORT/reset > /dev/null 2>&1
+
+# Publish message to SNS
+aws --endpoint-url "$LOCALSTACK" sns publish \
+    --topic-arn "$TOPIC_ARN" \
+    --subject "order.created" \
+    --message '{"id":"ord_789","amount":4999}' \
+    > /dev/null 2>/dev/null
+
+sleep 3
+
+# Check if mock received the delivery
+COUNT=$(curl -sf http://127.0.0.1:$MOCK_PORT/count 2>/dev/null || echo "0")
+if [ "$COUNT" -ge 1 ] 2>/dev/null; then
+    pass "SNS notification delivered to handler (count=$COUNT)"
+else
+    fail "SNS delivery" "expected >=1, got $COUNT"
+fi
+
+# Check payload content
+RECEIVED=$(curl -sf http://127.0.0.1:$MOCK_PORT/received 2>/dev/null || echo "[]")
+HAS_PAYLOAD=$(echo "$RECEIVED" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+if d:
+    body = d[0].get('body', '')
+    print('yes' if 'ord_789' in body or '4999' in body else 'no')
+else:
+    print('no')
+" 2>/dev/null || echo "no")
+
+[ "$HAS_PAYLOAD" = "yes" ] && pass "SNS message payload preserved" || fail "Payload" "ord_789 not found in delivered body"
+
+########################################
+echo ""
+echo "=== Test 3: Direct SNS notification (without LocalStack) ==="
+########################################
+
+# Send a fake SNS notification directly to qhook (skip_verify is on)
+curl -sf http://127.0.0.1:$MOCK_PORT/reset > /dev/null 2>&1
+
+HTTP_CODE=$(curl -s --max-time 3 -o /dev/null -w "%{http_code}" \
+    -X POST "http://127.0.0.1:$QHOOK_PORT/sns/my-sns" \
+    -H "Content-Type: text/plain" \
+    -H "x-amz-sns-message-type: Notification" \
+    -d '{
+        "Type": "Notification",
+        "MessageId": "test-msg-001",
+        "TopicArn": "arn:aws:sns:us-east-1:000000000000:test",
+        "Subject": "user.signup",
+        "Message": "{\"user_id\": \"usr_42\", \"type\": \"user.signup\"}",
+        "Timestamp": "2024-01-01T00:00:00.000Z",
+        "SignatureVersion": "1",
+        "Signature": "dGVzdA==",
+        "SigningCertURL": "https://sns.us-east-1.amazonaws.com/fake.pem"
+    }')
+
+[ "$HTTP_CODE" = "200" ] && pass "Direct SNS notification accepted (200)" || fail "Direct SNS" "got $HTTP_CODE"
+
+sleep 2
+
+COUNT=$(curl -sf http://127.0.0.1:$MOCK_PORT/count 2>/dev/null || echo "0")
+[ "$COUNT" -ge 1 ] 2>/dev/null && pass "Direct SNS delivered to handler (count=$COUNT)" || fail "Direct SNS delivery" "count=$COUNT"
+
+# Check event type was extracted from Message.type
+RECEIVED=$(curl -sf http://127.0.0.1:$MOCK_PORT/received 2>/dev/null || echo "[]")
+HAS_USER=$(echo "$RECEIVED" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+if d:
+    body = d[0].get('body', '')
+    print('yes' if 'usr_42' in body else 'no')
+else:
+    print('no')
+" 2>/dev/null || echo "no")
+[ "$HAS_USER" = "yes" ] && pass "SNS message unwrapped correctly" || fail "SNS unwrap" "usr_42 not found"
+
+########################################
+echo ""
+echo "=== Test 4: CloudEvents binary mode ==="
+########################################
+
+curl -sf http://127.0.0.1:$MOCK_PORT/reset > /dev/null 2>&1
+
+HTTP_CODE=$(curl -s --max-time 3 -o /dev/null -w "%{http_code}" \
+    -X POST "http://127.0.0.1:$QHOOK_PORT/webhooks/my-sns" \
+    -H "Content-Type: application/json" \
+    -d '{"data": "test"}' 2>/dev/null)
+
+# my-sns is type:sns, not webhook — should return 404
+[ "$HTTP_CODE" = "404" ] && pass "SNS source rejects webhook route (404)" || fail "Route isolation" "got $HTTP_CODE"
+
+########################################
+echo ""
+echo "=== Test 5: Unknown SNS source → 404 ==="
+########################################
+
+HTTP_CODE=$(curl -s --max-time 3 -o /dev/null -w "%{http_code}" \
+    -X POST "http://127.0.0.1:$QHOOK_PORT/sns/nonexistent" \
+    -H "Content-Type: text/plain" \
+    -d '{}')
+
+[ "$HTTP_CODE" = "404" ] && pass "Unknown SNS source returns 404" || fail "Unknown SNS" "got $HTTP_CODE"
+
+########################################
+echo ""
+echo "==============================="
+echo -e "Results: ${GREEN}${PASS} passed${NC}, ${RED}${FAIL} failed${NC}"
+echo "==============================="
+
+[ $FAIL -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- **CloudEvents**: Automatically detect binary mode (`ce-type` header) and structured mode (`application/cloudevents+json`). Forward `ce-*` headers to handlers on delivery.
- **AWS SNS input**: New `POST /sns/{source}` endpoint with automatic subscription confirmation, SNS message envelope unwrapping, and X.509 certificate signature verification (SHA1/SHA256).
- **Testing**: `skip_verify` option for LocalStack/testing. 34 unit tests + 22 E2E tests (including SNS with LocalStack).
- **Developer experience**: devcontainer with LocalStack, `CLAUDE.md` dev guide, `KANBAN.md` task board.

## Changed files
- `src/api.rs` — SNS handler, CloudEvents detection, event type extraction
- `src/verify.rs` — SNS X.509 signature verification, SnsMessage struct
- `src/config.rs` — `skip_verify` option on SourceConfig
- `src/queue.rs` — Forward `ce-*` headers on outbound delivery
- `src/db.rs` — `get_event_headers` method
- `Cargo.toml` — Version bump to 0.2.0, add `rsa`, `sha1`, `pkcs1`, `x509-parser`
- `README.md` — SNS, CloudEvents, architecture docs
- `docs/why-qhook.md` — SNS comparison added
- `tests/e2e.sh` — CloudEvents E2E test added
- `tests/e2e_sns.sh` — New SNS E2E tests with LocalStack

## Test plan
- [x] `cargo test` — 34 unit tests pass
- [x] `bash tests/e2e.sh` — 14 E2E tests pass
- [x] `bash tests/e2e_sns.sh` — 8 SNS E2E tests pass (with LocalStack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)